### PR TITLE
Allow ramsey/uuid 4.7 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "ramsey/uuid": "^3.5",
+        "ramsey/uuid": "^3.5 || ^4.7",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR includes the `^4.7` constraint to `ramsey/uuid` so that projects that rely on the latest release of that package can follow through without conflicts.
The tests don't show any regression/issue afaik.